### PR TITLE
Add datafieldenc = base64 flag

### DIFF
--- a/src/Ipfs/Commands/IpfsObject.cs
+++ b/src/Ipfs/Commands/IpfsObject.cs
@@ -87,6 +87,7 @@ namespace Ipfs.Commands
             var flags = new Dictionary<string, string>();
 
             flags.Add("encoding", GetIpfsEncodingValue(IpfsEncoding.Json));
+            flags.Add("datafieldenc", GetIpfsEncodingValue(IpfsEncoding.Base64));
 
             //Thanks to @slothbag for this snippet
             MultipartFormDataContent content = new MultipartFormDataContent();
@@ -134,6 +135,8 @@ namespace Ipfs.Commands
                     return "json";
                 case IpfsEncoding.Protobuf:
                     return "protobuf";
+                case IpfsEncoding.Base64:
+                    return "base64";
                 default:
                     return null;
             }

--- a/src/Ipfs/IpfsEncoding.cs
+++ b/src/Ipfs/IpfsEncoding.cs
@@ -3,6 +3,7 @@
     public enum IpfsEncoding
     {
         Json,
-        Protobuf
+        Protobuf,
+        Base64
     }
 }


### PR DESCRIPTION
This patch utilises the new base64 enc flag for IPFS to allow the Data field in a MerkleDAG node to be sent as Base64 and decoded to byte array before being hashed and stored.

See IPFS PR here https://github.com/ipfs/go-ipfs/pull/2520
See longer IPFS discussion here https://github.com/ipfs/go-ipfs/issues/1582
See net-ipfs-api serialization issue here https://github.com/TrekDev/net-ipfs-api/issues/4
