### PR TITLE
Add support for the 'shutdown' command added in IPFS 0.4.10

### DIFF
--- a/src/Ipfs/Commands/IpfsRoot.cs
+++ b/src/Ipfs/Commands/IpfsRoot.cs
@@ -353,6 +353,25 @@ namespace Ipfs.Commands
         }
 
         /// <summary>
+        /// Shuts down the IPFS daemon
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <remarks>Currently there is no way to determine whether or not the command succeeded
+        ///          since the daemon shuts down before sending a response</remarks>
+        public async Task Shutdown(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            try
+            {
+                await ExecuteGetAsync("shutdown", cancellationToken);
+            }
+            catch (HttpRequestException)
+            {                
+                /* Currently shutdown always results in a HttpRequestException 
+                 * because the daemon shuts down before sending a response */
+            }
+        }
+
+        /// <summary>
         /// An introduction to IPFS
         ///
         /// This is a tour that takes you through various IPFS concepts,

--- a/src/Ipfs/IpfsClient.cs
+++ b/src/Ipfs/IpfsClient.cs
@@ -570,6 +570,17 @@ namespace Ipfs
         }
 
         /// <summary>
+        /// Shuts down the IPFS daemon
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <remarks>Currently there is no way to determine whether or not the command succeeded
+        ///          since the daemon shuts down before sending a response</remarks>
+        public async Task Shutdown(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await Root.Shutdown(cancellationToken);
+        }
+        
+        /// <summary>
         /// An introduction to IPFS
         ///
         /// This is a tour that takes you through various IPFS concepts,


### PR DESCRIPTION
Support for the shutdown command (ipfs/go-ipfs#3884)
Currently it catches the exception that will always be thrown when issuing this command.
We could expand it so that it checks whether or not the deamon is still up or even up in the first place,
or we could wait until the issue is fixed in IPFS and it sends a response before actually shutting down.