### PR TITLE
Proof of concept fix for issue #16

### DIFF
--- a/src/Ipfs.Test/CommandTests.cs
+++ b/src/Ipfs.Test/CommandTests.cs
@@ -198,5 +198,16 @@ namespace Ipfs.Test
                 Console.WriteLine("The operation has been canceled properly");
             }
         }
+
+        [TestMethod]
+        public void ShouldBeAbleToListSwarmPeers()
+        {
+            using (var client = new IpfsClient())
+            {
+                var task = client.Swarm.Peers();
+                task.Wait();
+                var peers = task.Result;               
+            }
+        }
     }
 }

--- a/src/Ipfs/Commands/IpfsSwarm.cs
+++ b/src/Ipfs/Commands/IpfsSwarm.cs
@@ -1,4 +1,6 @@
 ﻿using Ipfs.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -142,10 +144,12 @@ namespace Ipfs.Commands
         {
             HttpContent content = await ExecuteGetAsync("peers", cancellationToken);
             string json = await content.ReadAsStringAsync();
-            var swarmPeers = _jsonSerializer.Deserialize<IDictionary<string, IList<string>>>(json);
-            return swarmPeers
-                .SelectMany(x => x.Value)
-                .Select(x => new MultiAddress(x)).ToArray();
+                       
+            dynamic results = JObject.Parse(json);
+            IEnumerable<dynamic> peers = results.Peers;
+            return peers.Select(p => p.Addr)
+                        .Select(a => new MultiAddress(a.ToString()))
+                        .ToArray();
         }
     }
 }

--- a/src/Ipfs/Ipfs.csproj
+++ b/src/Ipfs/Ipfs.csproj
@@ -91,15 +91,13 @@
     <Compile Include="Utilities\UriHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\portable-net45+win8+wp8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Ipfs/packages.config
+++ b/src/Ipfs/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="portable45-net45+win8+wpa81" />
 </packages>


### PR DESCRIPTION
A proof of concept / proposed fix for issue #16 
By deserializing into a dynamic object we can simply get the data we need and ignore everything  
else without having to worry too much about upcoming additions to the json returned by the API.

If this looks ok, it can be applied to the other methods where the issue exists as well.