### PR TITLE
Fix for issue #21 - IpfsClient.Cat("...") throws OutOfMemoryException

### DIFF
--- a/src/Ipfs.Test/ClientTests.cs
+++ b/src/Ipfs.Test/ClientTests.cs
@@ -1,8 +1,12 @@
 ﻿using Ipfs.Test.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 namespace Ipfs.Test
 {
@@ -29,6 +33,91 @@ namespace Ipfs.Test
             catch (AggregateException ex)
             {
                 throw ex.InnerException;
+            }
+        }
+
+        [TestMethod]
+        public async Task ClientShouldBeAbleToDownloadLargeFiles()
+        {
+           /* This test is a bit long because it relies of having 
+            * a large file available through IPFS and the best way to
+            * ensure that is to simply create that file in the first place */
+            
+            var sourceFile = Path.GetTempFileName();
+            var targetFile = Path.GetTempFileName();
+
+            try
+            {
+                using (var client = new IpfsClient())
+                {
+                    string sourceHash;                    
+                    await CreateDummyFileAsync(sourceFile);
+
+                    using (var sourceStream = File.OpenRead(sourceFile))
+                    using (var ipfsSourceStream = new IpfsStream("source", sourceStream))
+                    {
+                        var hash = await client.Add(ipfsSourceStream);
+                        sourceHash = hash.ToString();
+                    }
+
+                    using (var stream = await client.Cat(sourceHash))
+                    using (var outputFilename = File.OpenWrite(targetFile))
+                    {
+                        await stream.CopyToAsync(outputFilename);
+                    }
+
+                    await client.Pin.Rm(sourceHash);
+
+                    Assert.IsTrue(FileHashesAreEqual(sourceFile, targetFile));
+                }
+            }
+            catch
+            {
+                throw;
+            }
+            finally
+            {
+                if (File.Exists(sourceFile))
+                {
+                    File.Delete(sourceFile);
+                }
+
+                if (File.Exists(targetFile))
+                {
+                    File.Delete(targetFile);
+                }
+            }
+        }
+
+        private static async Task CreateDummyFileAsync(string filename, int sizeMb = 500)
+        {
+            using (var stream = File.OpenWrite(filename))
+            {
+                var buffer = new byte[1024 * 1024];
+
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    buffer[i] = 0xFF;
+                }
+
+                for (int i = 0; i < sizeMb; i++)
+                {
+                    await stream.WriteAsync(buffer, 0, buffer.Length);
+                }
+            }
+        }
+
+        private static bool FileHashesAreEqual(string leftFile, string rightFile)
+        {
+            using (var sha = new SHA256CryptoServiceProvider())
+            {
+                using (var leftStream = File.OpenRead(leftFile))
+                using (var rightStream = File.OpenRead(rightFile))
+                {
+                    var leftHash = sha.ComputeHash(leftStream);
+                    var rightHash = sha.ComputeHash(rightStream);
+                    return leftHash.SequenceEqual(rightHash);
+                }
             }
         }
     }

--- a/src/Ipfs/Commands/IpfsRoot.cs
+++ b/src/Ipfs/Commands/IpfsRoot.cs
@@ -73,8 +73,7 @@ namespace Ipfs.Commands
         /// <returns>A stream to your file</returns>
         public async Task<Stream> Cat(string ipfsPath, CancellationToken cancellationToken = default(CancellationToken))
         {
-            HttpContent content = await ExecuteGetAsync("cat", ipfsPath, cancellationToken);
-            return await content.ReadAsStreamAsync();
+            return await ExecuteGetStreamAsync("cat", ipfsPath, cancellationToken);            
         }
 
         /// <summary>


### PR DESCRIPTION
Get the Stream from the HttpClient and return it directly as opposed
to downloading everything into a HttpResponseMessage first.

In order to do so I added `ExecuteGetStreamAsync` methods and tried to  
follow the original structure as much as possible.

I included a test that generates a large file, adds it to IPFS and then
tries to download it.