### PR TITLE
Added overloads for IpfsClient.Add in order to simplify the process of adding data

### DIFF
--- a/src/Ipfs.Test/CommandTests.cs
+++ b/src/Ipfs.Test/CommandTests.cs
@@ -332,5 +332,41 @@ namespace Ipfs.Test
                 }
             }
         }
+
+        [TestMethod]
+        public async Task ShouldBeAbleToAddTextUsingDefaultEncoding()
+        {
+            using (var client = new IpfsClient())
+            {
+                var originalText = DateTime.Now.ToLongTimeString();
+                var result = await client.Add("MyHello", originalText);
+                var hash = result.ToString();
+
+                using (var catStream = await client.Cat(hash))
+                using (var reader = new StreamReader(catStream))
+                {
+                    var text = reader.ReadToEnd();
+                    Assert.AreEqual(text, originalText);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task ShouldBeAbleToAddTextUsingASCIIEncoding()
+        {
+            using (var client = new IpfsClient())
+            {
+                var originalText = DateTime.Now.ToLongTimeString();
+                var result = await client.Add("MyHello", originalText, Encoding.ASCII);
+                var hash = result.ToString();
+
+                using (var catStream = await client.Cat(hash))
+                using (var reader = new StreamReader(catStream))
+                {
+                    var text = reader.ReadToEnd();
+                    Assert.AreEqual(text, originalText);
+                }
+            }
+        }
     }
 }

--- a/src/Ipfs/IpfsClient.cs
+++ b/src/Ipfs/IpfsClient.cs
@@ -415,6 +415,42 @@ namespace Ipfs
         }
 
         /// <summary>
+        /// Add an object to ipfs.
+        /// Adds the contents of the stream to ipfs
+        /// </summary>
+        /// <param name="name">A name assigned to the object</param>
+        /// <param name="stream">The stream containing the data to be added</param>
+        /// <param name="quiet">Write minimal output</param>
+        /// <param name="trickle">Use trickle-dag format for dag generation</param>
+        /// <param name="cancellationToken">Token allowing you to cancel the request</param>
+        /// <returns></returns>
+        public async Task<MerkleNode> Add(string name, Stream stream, bool quiet = false, bool trickle = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var ipfsStream = new IpfsStream(name, stream))
+            {
+                return await Add(ipfsStream, false, quiet, false, trickle, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Add an object to ipfs.
+        /// Adds the contents of the byte[] to ipfs
+        /// </summary>
+        /// <param name="name">A name assigned to the object</param>
+        /// <param name="data">The data to be added</param>
+        /// <param name="quiet">Write minimal output</param>
+        /// <param name="trickle">Use trickle-dag format for dag generation</param>
+        /// <param name="cancellationToken">Token allowing you to cancel the request</param>
+        /// <returns></returns>
+        public async Task<MerkleNode> Add(string name, byte[] data, bool quiet = false, bool trickle = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var stream = new MemoryStream(data))
+            {
+                return await Add(name, stream, quiet, trickle, cancellationToken);
+            }
+        }
+
+        /// <summary>
         /// Show IPFS object data
         /// Retrieves the object named by <ipfs-path> and outputs the data
         /// it contains.

--- a/src/Ipfs/IpfsClient.cs
+++ b/src/Ipfs/IpfsClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -450,6 +451,37 @@ namespace Ipfs
             }
         }
 
+        /// <summary>
+        /// Add an object, in this case a string, to ipfs.
+        /// The string will be UTF8 encoded
+        /// </summary>
+        /// <param name="name">A name assigned to the object</param>
+        /// <param name="text">The text to be added</param>        
+        /// <param name="quiet">Write minimal output</param>
+        /// <param name="trickle">Use trickle-dag format for dag generation</param>
+        /// <param name="cancellationToken">Token allowing you to cancel the request</param>
+        /// <returns></returns>
+        public async Task<MerkleNode> Add(string name, string text, bool quiet = false, bool trickle = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await Add(name, text, Encoding.UTF8, quiet, trickle, cancellationToken);
+        }
+
+        /// <summary>
+        /// Add an object, in this case a string, to ipfs.
+        /// </summary>
+        /// <param name="name">A name assigned to the object</param>
+        /// <param name="text">The text to be added</param>
+        /// <param name="encoding">The encoding to be used in order to convert the string to bytes</param>
+        /// <param name="quiet">Write minimal output</param>
+        /// <param name="trickle">Use trickle-dag format for dag generation</param>
+        /// <param name="cancellationToken">Token allowing you to cancel the request</param>
+        /// <returns></returns>
+        public async Task<MerkleNode> Add(string name, string text, Encoding encoding, bool quiet = false, bool trickle = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var data = encoding.GetBytes(text);
+            return await Add(name, data, quiet, trickle, cancellationToken);
+        }
+        
         /// <summary>
         /// Show IPFS object data
         /// Retrieves the object named by <ipfs-path> and outputs the data


### PR DESCRIPTION
The command line is most commonly used to add files to IPFS,   
but when used as part of another application it's often usefull to add data directly  
as opposed to having to write it to a file first. This data might be an array of bytes,   
a string or another stream (not to be confused with IpfsStream).

To justify the additions, consider the following (eleaborate) examples:

1. Serializing objects to JSON and adding them directly

```
using (var client = new IpfsClient())
{
    var bossOfTheYear = new
    {
        Name = "Bruce",
        Surname = "Wayne",
        Nickname = "The Dark Knight",
        Occupation = "CEO/Philanthropist",
    };

    var json = JsonConvert.SerializeObject(bossOfTheYear);
    var result = await client.Add("batman", json);
    var hash = result.ToString();
    Console.WriteLine(hash);
                
    using (var stream = await client.Cat(hash))
    using (var reader = new StreamReader(stream))
    {
        json = reader.ReadToEnd();
        dynamic batman = JsonConvert.DeserializeObject(json);
        Console.WriteLine($"{batman.Name} {batman.Surname} - {batman.Nickname}, {batman.Occupation}");                    
    }
}
```

2. Streaming protobuf serialized objects directly to IPFS:

```
[ProtoContract]
private class Employee
{
    [ProtoMember(1, IsRequired = true)]
    public int Id { get; set; }

    [ProtoMember(2, IsRequired = true)]
    public string Name { get; set; }

    [ProtoMember(3, IsRequired = true)]
    public string Surname { get; set; }

    [ProtoMember(4, IsRequired = false)]
    public List<Contract> Contracts { get; set; } = new List<Contract>();
}

[ProtoContract]
public class Contract
{
    [ProtoMember(1, IsRequired = true)]
    public int Id { get; set; }

    [ProtoMember(2, IsRequired = true)]
    public string Name { get; set; }
}


private static async void RunExample()
{
    using (var client = new IpfsClient())
    using (var stream = new MemoryStream())
    {
        var employee = new Employee() { Id = 2008, Name = "SpongeBob", Surname = "Quarepants" };
        employee.Contracts.Add(new Contract() { Id = 1, Name = "Krusty Krab" });
        employee.Contracts.Add(new Contract() { Id = 2, Name = "Mrs. Puff's Boating School" });

        Serializer.Serialize(stream, employee);
        stream.Position = 0;

        var result = await client.Add("spongebob", stream);
        var hash = result.ToString();
        Console.WriteLine(hash);

        using (var responseStream = await client.Cat(hash))
        {
            var spongeClone = Serializer.Deserialize<Employee>(responseStream);
            Console.WriteLine($"{spongeClone.Id}, {spongeClone.Name} ${spongeClone.Surname}");
            foreach (var contract in spongeClone.Contracts)
            {
                Console.WriteLine($"\t{contract.Id}, {contract.Name}");
            }
        }
    }
}

```

And I'm sure there's plenty of other use cases.

