### PR TITLE
IpfsStatsBw TotalIn and TotalOut properties should be of type double

### DIFF
--- a/src/Ipfs/Json/IpfsStatsBw.cs
+++ b/src/Ipfs/Json/IpfsStatsBw.cs
@@ -3,8 +3,8 @@
 
     public class IpfsStatsBw
     {
-        public int TotalIn { get; set; }
-        public int TotalOut { get; set; }
+        public double TotalIn { get; set; }
+        public double TotalOut { get; set; }
         public double RateIn { get; set; }
         public double RateOut { get; set; }
     }


### PR DESCRIPTION
The TotalIn and TotalOut values are to big to be stored in an int